### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/AddressService/AddressService.AzureFunction/AddressService.AzureFunction.csproj
+++ b/AddressService/AddressService.AzureFunction/AddressService.AzureFunction.csproj
@@ -5,7 +5,7 @@
     <UserSecretsId>2ab26b8f-fafb-4345-a188-210580b87104</UserSecretsId>
 	</PropertyGroup>
 	<ItemGroup>
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Marvin.StreamExtensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />

--- a/AddressService/AddressService.AzureFunction/AddressService.AzureFunction.csproj
+++ b/AddressService/AddressService.AzureFunction/AddressService.AzureFunction.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	<ItemGroup>
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
-    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Marvin.StreamExtensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />

--- a/AddressService/AddressService.Core/AddressService.Core.csproj
+++ b/AddressService/AddressService.Core/AddressService.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Marvin.StreamExtensions" Version="1.1.0" />
     <PackageReference Include="MediatR" Version="8.0.1" />

--- a/AddressService/AddressService.Core/AddressService.Core.csproj
+++ b/AddressService/AddressService.Core/AddressService.Core.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
-    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Marvin.StreamExtensions" Version="1.1.0" />
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="NewRelic.Agent.Api" Version="8.27.139" />

--- a/AddressService/AddressService.Handlers/AddressService.Handlers.csproj
+++ b/AddressService/AddressService.Handlers/AddressService.Handlers.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />

--- a/AddressService/AddressService.Handlers/AddressService.Handlers.csproj
+++ b/AddressService/AddressService.Handlers/AddressService.Handlers.csproj
@@ -15,7 +15,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="MediatR" Version="8.0.1" />
 		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
 	</ItemGroup>

--- a/AddressService/AddressService.Mappers/AddressService.Mappers.csproj
+++ b/AddressService/AddressService.Mappers/AddressService.Mappers.csproj
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 	</ItemGroup>
 	<ItemGroup>

--- a/AddressService/AddressService.Mappers/AddressService.Mappers.csproj
+++ b/AddressService/AddressService.Mappers/AddressService.Mappers.csproj
@@ -8,7 +8,7 @@
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
 		<PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference ReplaceParameters="true" Include="..\AddressService.Core\AddressService.Core.csproj">

--- a/AddressService/AddressService.PostcodeLoader/AddressService.PostcodeLoader.csproj
+++ b/AddressService/AddressService.PostcodeLoader/AddressService.PostcodeLoader.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.379" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />

--- a/AddressService/AddressService.PostcodeLoader/AddressService.PostcodeLoader.csproj
+++ b/AddressService/AddressService.PostcodeLoader/AddressService.PostcodeLoader.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="HelpMyStreet.Contracts" Version="1.1.305" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
-    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>

--- a/AddressService/AddressService.Repo/AddressService.Repo.csproj
+++ b/AddressService/AddressService.Repo/AddressService.Repo.csproj
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
 		<PackageReference Include="Dapper" Version="2.0.35" />
-		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.379" />
 		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />

--- a/AddressService/AddressService.Repo/AddressService.Repo.csproj
+++ b/AddressService/AddressService.Repo/AddressService.Repo.csproj
@@ -8,7 +8,7 @@
 		<PackageReference Include="AutoMapper" Version="9.0.0" />
 		<PackageReference Include="Dapper" Version="2.0.35" />
 		<PackageReference Include="HelpMyStreet.PostcodeCoordinates.EF" Version="1.1.305" />
-		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+		<PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
 		<PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />

--- a/AddressService/AddressService.UnitTests/AddressService.UnitTests.csproj
+++ b/AddressService/AddressService.UnitTests/AddressService.UnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.305" />
+    <PackageReference Include="HelpMyStreet.Utils" Version="1.1.379" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />


### PR DESCRIPTION
3 packages were updated in 7 projects:
`HelpMyStreet.Utils`, `HelpMyStreet.Contracts`, `HelpMyStreet.PostcodeCoordinates.EF`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `HelpMyStreet.Utils` to `1.1.379` from `1.1.305`
`HelpMyStreet.Utils 1.1.379` was published at `2020-09-23T13:56:34Z`, 2 hours ago

7 project updates:
Updated `AddressService\AddressService.AzureFunction\AddressService.AzureFunction.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Core\AddressService.Core.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Handlers\AddressService.Handlers.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Mappers\AddressService.Mappers.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.PostcodeLoader\AddressService.PostcodeLoader.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Repo\AddressService.Repo.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.UnitTests\AddressService.UnitTests.csproj` to `HelpMyStreet.Utils` `1.1.379` from `1.1.305`

NuKeeper has generated a patch update of `HelpMyStreet.Contracts` to `1.1.379` from `1.1.305`
`HelpMyStreet.Contracts 1.1.379` was published at `2020-09-23T13:56:26Z`, 2 hours ago

5 project updates:
Updated `AddressService\AddressService.AzureFunction\AddressService.AzureFunction.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Core\AddressService.Core.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Handlers\AddressService.Handlers.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.Mappers\AddressService.Mappers.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.305`
Updated `AddressService\AddressService.PostcodeLoader\AddressService.PostcodeLoader.csproj` to `HelpMyStreet.Contracts` `1.1.379` from `1.1.305`

NuKeeper has generated a patch update of `HelpMyStreet.PostcodeCoordinates.EF` to `1.1.379` from `1.1.305`
`HelpMyStreet.PostcodeCoordinates.EF 1.1.379` was published at `2020-09-23T13:56:30Z`, 2 hours ago

1 project update:
Updated `AddressService\AddressService.Repo\AddressService.Repo.csproj` to `HelpMyStreet.PostcodeCoordinates.EF` `1.1.379` from `1.1.305`

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
